### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: Main
+permissions:
+  contents: read
 on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   push:
@@ -127,6 +129,8 @@ jobs:
     name: Publish (NuGet)
     runs-on: ubuntu-latest
     needs: pack
+    permissions:
+      packages: write
     environment:
       # name: ${{ github.ref == 'refs/heads/master' && 'prod' || 'dev' }}
       name: ${{ 'dev' }}
@@ -150,6 +154,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [versioning, pack]
     if: ${{ github.ref == 'refs/heads/master' }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ztepsic/zed/security/code-scanning/7](https://github.com/ztepsic/zed/security/code-scanning/7)

To fix the problem, explicitly define GITHUB_TOKEN permissions in the workflow, using the principle of least privilege. This can be done at the workflow root (applies to all jobs) and then overridden per job if a specific job needs more or fewer permissions. For jobs that only need to read the repository (e.g., checkout, build, test, version calculation), `contents: read` is typically sufficient. For jobs that publish packages or create releases, additional scopes like `packages: write` or `contents: write` may be necessary, but we should not grant more than required.

Best fix with minimal functional change:

- Add a root-level `permissions` block after `name: Main` that sets a safe default, e.g. `contents: read`. This satisfies the CodeQL recommendation and constrains all jobs by default.
- Then, for jobs that clearly need to write to GitHub or packages, add job-level `permissions` blocks that extend as needed:
  - `versioning`, `build`, `test`, and `pack` only read the repo and work with local artifacts, so they can rely on the inherited `contents: read`.
  - `publish` uses `secrets.GITHUB_TOKEN` to push to a NuGet source. For GitHub Packages, this requires `packages: write`; for external NuGet, the GitHub token may only be used to authenticate to GitHub APIs, but granting `packages: write` is a reasonable minimal extension without loosening `contents`.
  - `release` uses `GITHUB_TOKEN` to perform GitHub release/tag operations in `release-nuget`. That typically requires `contents: write` (e.g., for creating tags/releases). We’ll add a `permissions` block to that job with `contents: write`.

Concretely in `.github/workflows/main.yml`:

- Insert:

```yml
permissions:
  contents: read
```

after line 3 (`name: Main`).

- Add a `permissions` block to the `publish` job (around line 126) with `packages: write`.
- Add a `permissions` block to the `release` job (around line 148) with `contents: write`.

No external libraries or dependencies are needed; changes are limited to YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
